### PR TITLE
Support CSV as stats file format

### DIFF
--- a/doc/creating-layers.md
+++ b/doc/creating-layers.md
@@ -81,6 +81,27 @@ For layers with up to a few hundred features, creating a GeoJSON layer is
 easy to do and performant enough. For larger layers, you'll probably need
 a vector tile layer for performance.
 
+## The Stats Data File
+The stats data file provides historic information like the number of the layer's features at a given date. It can be supplied as a json or a CSV file (in the latter case, the URL must end with `.csv`.).
+
+The json format is a simple array of arrays:
+```
+[
+  [
+    "2017-03-17",
+    311007
+  ],
+  ...
+]
+```
+
+The CSV file requires two comma separated columns 'Date' and 'Count', the date is expected in yyyy-MM-dd format:
+```
+Date,Count
+2017-03-17,311007
+...
+```
+
 
 ## CORS-Headers
 

--- a/site/js/app.js
+++ b/site/js/app.js
@@ -373,7 +373,14 @@ function switch_to_layer(id) {
     }
 
     if (layer.stats_data_url()) {
-        d3.json(layer.stats_data_url()).then(init_stats);
+        if (layer.stats_data_url().endsWith('.csv')) {
+            d3.csv(layer.stats_data_url(),function (d) {
+                    return [d.Date, +d.Count];
+                })
+            .then(init_stats);
+        } else {
+            d3.json(layer.stats_data_url()).then(init_stats);
+        }
     } else {
         document.getElementById('canvas_stats').textContent = 'No statistics available for this layer';
     }


### PR DESCRIPTION
It's easier to just append feature counts to CSV stats file than appending to a JSON array.

This PR adds support for CSV stats files and documentation for stats file format.