### PR TITLE
Add an explicit "add source" button to make form more intuitive

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -23,6 +23,7 @@
         <div id="source-input">
             <label for="add_source">Add data source URL:</label>
             <input type="url" name="name" id="add_source" value="" size="60">
+            <button id="button-add-source">Add source</button>
             <button id="remove-all-sources">Remove all sources</button>
         </div>
         <div id="sources-list">

--- a/site/js/app.js
+++ b/site/js/app.js
@@ -833,8 +833,14 @@ document.addEventListener('DOMContentLoaded', function() {
         }
     });
 
-    document.getElementById('add_source').addEventListener('change', function(event) {
-        load_data_source(this.value);
+    document.getElementById('button-add-source').addEventListener('click', function(event) {
+	load_data_source(document.getElementById('add_source').value);
+    });
+
+    document.getElementById('add_source').addEventListener('keyup', function(event) {
+        if (event.keyCode == 13) {
+            load_data_source(this.value);
+        }
     });
 
     document.getElementById('overlay-layers-open').addEventListener('click', open_layers_config);


### PR DESCRIPTION
I find it unintuitive not to have a dedicated "add source" button but have the hidden behaviour to react on the `change` event of the input field.