### PR TITLE
Added the 'n/@id' pattern for properties where the value should be co…

### DIFF
--- a/site/js/app.js
+++ b/site/js/app.js
@@ -349,15 +349,22 @@ function popup_content(feature) {
             var value = props[p].toString();
             if (p == 'geometry') {
                 continue;
-            } else if (p == 'node_id' && value.match(re_numeric)) {
-                p = 'Node ID';
-                value = '<a target="_blank" href="https://www.openstreetmap.org/node/' + value + '">' + value + '</a>';
-            } else if (p == 'way_id' && value.match(re_numeric)) {
-                p = 'Way ID';
-                value = '<a target="_blank" href="https://www.openstreetmap.org/way/' + value + '">' + value + '</a>';
-            } else if (p == 'relation_id' && value.match(re_numeric)) {
-                p = 'Relation ID';
-                value = '<a target="_blank" href="https://www.openstreetmap.org/relation/' + value + '">' + value + '</a>';
+            } else if ((p == 'node_id' || p == 'way_id' || p == 'relation_id' || p.match('^[nwr]\/@id')) && value.match(re_numeric)) {
+                //Get the data type ('n' or 'w' or 'r')
+                data_type = p.charAt(0)
+                if (p.match('^[nwr]\/@id')) {
+                    p = p.slice(5)
+                } else {
+                    //For example transform 'node_id' into 'Node ID'
+                    splitted = p.split('_')
+                    p = splitted[0].charAt(0).toUpperCase() + splitted[0].slice(1) + ' ' + splitted[1].toUpperCase()
+                }
+                types_mapping = {
+                    n: 'node',
+                    w: 'way',
+                    r: 'relation'
+                }
+                value = '<a target="_blank" href="https://www.openstreetmap.org/' + types_mapping[data_type] + '/' + value + '">' + value + '</a>';
             } else if (p == '@id' && get_selection_object(feature) !== undefined) {
                 var id = get_selection_object(feature);
                 p = id[0].charAt(0).toUpperCase() + id[0].slice(1) + ' ID';


### PR DESCRIPTION
### New functionality

Currently the only way to display a property value as node osm id link is to use `node_id` as property key.

I added a new pattern so that we can have a custom property name but also a link to an osm id in the value. (For example `Node in common = 2986863703` with a link on the node id)

Now, by starting the property name with `n/@id` osmoscope will automatically transform the value to an osm id link (just like it was done with `node_id`) and the `n/@id` will be removed from the beginning of the property name. 

It also works for ways with `w/@id` and relations with `r/@id`. 
For example, we can now write a property like this: `n/@idNode in common = 2986863703`

If you agree with that pattern, it could be added to the documentation.

(I can rebase this if necessary).