### PR TITLE
Use min value instead of zero for Y-axis values

### DIFF
--- a/site/js/app.js
+++ b/site/js/app.js
@@ -577,7 +577,7 @@ function init_stats(data) {
 /*    var t0 = new Date('2017-01-01');
         t1 = new Date('2017-08-01');*/
 
-    var max = d3.max(data, function(d) {
+    var bounds = d3.extent(data, function(d) {
         return d[1];
     });
 
@@ -586,7 +586,7 @@ function init_stats(data) {
                     .range([0, w]);
 
     var scale_y = d3.scaleLinear()
-                    .domain([0, max])
+                    .domain(bounds)
                     .range([h, 0]);
 
     var chart = d3.select('#canvas_stats').append('svg')


### PR DESCRIPTION
When the Y-axis values are far from zero, the chart depicts more representative data when the Y-axis domain is shrunk.

##### Before
![imagen](https://user-images.githubusercontent.com/817526/191509613-57910e93-6083-4b9b-b1fa-4fac1116c00a.png)
##### After
![imagen](https://user-images.githubusercontent.com/817526/191509904-6bd6bda4-7dcc-4787-861f-47f65c2ac81b.png)
